### PR TITLE
add Quantum Design DAT file type

### DIFF
--- a/marda_registry/data/filetypes/quantum-design-dat.yml
+++ b/marda_registry/data/filetypes/quantum-design-dat.yml
@@ -1,0 +1,24 @@
+---
+id: >-
+    quantum-design-dat
+name: >-
+    Quantum Design Data File
+description: >-
+    A csv-based text data file created by Quantum Design physical property measurement systems and magnetic property measurement systems, containing the results of physical property measurements of various types. The  measurements may be the result of processing from additional raw data, e.g. raw SQUID voltage data in a Quantum Design .rw.dat file.
+associated_vendors:
+    - Quantum Design
+subject:
+    - magnetometry
+    - resistivity
+    - heat capacity
+    - thermal measurements
+associated_instruments:
+    - Quantum Design PPMS
+    - Quantum Design DynaCool
+    - Quantum Design MPMS
+    - Quantum Design MPMS-XL
+    - Quantum Design MPMS3
+    - Quantum Design SquidVSM
+associated_software:
+    - Quantum Design MultiVu
+

--- a/marda_registry/data/filetypes/quantum-design-dat.yml
+++ b/marda_registry/data/filetypes/quantum-design-dat.yml
@@ -10,8 +10,10 @@ associated_vendors:
 subject:
     - magnetometry
     - resistivity
+    - transport
     - heat capacity
     - thermal measurements
+    - SQUID
 associated_instruments:
     - Quantum Design PPMS
     - Quantum Design DynaCool


### PR DESCRIPTION
A first draft of  the Quantum Design .dat file that is used for a variety of PPMS and MPMS systems from Quantum design