### PR TITLE
Implement `yadg` extractor

### DIFF
--- a/marda_registry/data/extractors/yadg
+++ b/marda_registry/data/extractors/yadg
@@ -40,5 +40,5 @@ usage: >-
     - cli:yadg extract {{ file_type }} {{ file_path }}
 instructions: >-
     Install the package into a Python 3.9+ environment with
-    `pip install yadg`. After activating the environment, the 
+    `pip install yadg`. After activating the environment, the
     `extract` entrypoint will be available at the command-line.

--- a/marda_registry/data/extractors/yadg
+++ b/marda_registry/data/extractors/yadg
@@ -1,0 +1,44 @@
+---
+id: >-
+    yadg
+name: >-
+    yet another datagram
+description: >-
+    yadg is a set of tools to extract and parse raw instrument data.
+subject:
+    - electrochemistry
+    - voltammetry
+    - impedance spectropscopy
+    - potentiometry
+    - gas chromatography
+    - liquid chromatography
+    - x-ray diffraction
+    - x-ray photoelectron spectroscopy
+citations:
+    - identifier: doi:10.21105/joss.04166
+      creators:
+          - P. Kraus
+          - N. Vetsch
+          - C. Battaglia
+      title: "yadg: yet another datagram"
+      type: article
+    - identifier: https://github.com/dgbowl/yadg
+      creators:
+          - P. Kraus
+          - N. Vetsch
+      title: yadg github repository
+      type: software
+    - identifier: doi:10.5281/zenodo.6547425
+      creators:
+          - P. Kraus
+          - N. Vetsch
+      title: "yadg: yet another datagram"
+      type: software
+source_repository_url: https://github.com/dgbowl/yadg
+documentation_url: https://dgbowl.github.io/yadg
+usage: >-
+    - cli:yadg extract {{ file_type }} {{ file_path }}
+instructions: >-
+    Install the package into a Python 3.9+ environment with
+    `pip install yadg`. After activating the environment, the 
+    `extract` entrypoint will be available at the command-line.

--- a/marda_registry/data/extractors/yadg
+++ b/marda_registry/data/extractors/yadg
@@ -15,7 +15,7 @@ subject:
     - x-ray diffraction
     - x-ray photoelectron spectroscopy
 citations:
-    - identifier: doi:10.21105/joss.04166
+    - uri: doi:10.21105/joss.04166
       creators:
           - P. Kraus
           - N. Vetsch
@@ -28,14 +28,14 @@ citations:
           - N. Vetsch
       title: yadg github repository
       type: software
-    - identifier: doi:10.5281/zenodo.6547425
+    - uri: doi:10.5281/zenodo.6547425
       creators:
           - P. Kraus
           - N. Vetsch
       title: "yadg: yet another datagram"
       type: software
-source_repository_url: https://github.com/dgbowl/yadg
-documentation_url: https://dgbowl.github.io/yadg
+source_repository: https://github.com/dgbowl/yadg
+documentation: https://dgbowl.github.io/yadg
 usage: >-
     - cli:yadg extract {{ file_type }} {{ file_path }}
 instructions: >-

--- a/marda_registry/data/extractors/yadg.yml
+++ b/marda_registry/data/extractors/yadg.yml
@@ -20,7 +20,7 @@ citations:
           - P. Kraus
           - N. Vetsch
           - C. Battaglia
-      title: "yadg: yet another datagram"
+      title: 'yadg: yet another datagram'
       type: article
     - identifier: https://github.com/dgbowl/yadg
       creators:
@@ -32,7 +32,7 @@ citations:
       creators:
           - P. Kraus
           - N. Vetsch
-      title: "yadg: yet another datagram"
+      title: 'yadg: yet another datagram'
       type: software
 source_repository: https://github.com/dgbowl/yadg
 documentation: https://dgbowl.github.io/yadg

--- a/marda_registry/data/extractors/yadg.yml
+++ b/marda_registry/data/extractors/yadg.yml
@@ -8,7 +8,8 @@ description: >-
 supported_filetypes:
     - id: biologic-mpr
       description: >-
-          Note: Several fields in file headers are not translated into meaningful parameters.
+          Note: Several fields in file headers are not translated into meaningful
+          parameters.
     - id: biologic-mpt
 subject:
     - electrochemistry

--- a/marda_registry/data/extractors/yadg.yml
+++ b/marda_registry/data/extractors/yadg.yml
@@ -36,7 +36,7 @@ citations:
       type: software
 source_repository: https://github.com/dgbowl/yadg
 documentation: https://dgbowl.github.io/yadg
-usage: >-
+usage:
     - cli:yadg extract {{ file_type }} {{ file_path }}
 instructions: >-
     Install the package into a Python 3.9+ environment with

--- a/marda_registry/data/extractors/yadg.yml
+++ b/marda_registry/data/extractors/yadg.yml
@@ -5,6 +5,11 @@ name: >-
     yet another datagram
 description: >-
     yadg is a set of tools to extract and parse raw instrument data.
+supported_filetypes:
+    - id: biologic-mpr
+      description: >-
+          Note: Several fields in file headers are not translated into meaningful parameters.
+    - id: biologic-mpt
 subject:
     - electrochemistry
     - voltammetry

--- a/marda_registry/data/extractors/yadg.yml
+++ b/marda_registry/data/extractors/yadg.yml
@@ -22,7 +22,7 @@ citations:
           - C. Battaglia
       title: 'yadg: yet another datagram'
       type: article
-    - identifier: https://github.com/dgbowl/yadg
+    - uri: https://github.com/dgbowl/yadg
       creators:
           - P. Kraus
           - N. Vetsch


### PR DESCRIPTION
Prerequisites: https://github.com/marda-alliance/metadata_extractors_schema/pull/14

Draft `Extractor` yaml file for `yadg`.