### PR TITLE
`yadg` extractor `usage` and `installation`

### DIFF
--- a/marda_registry/data/extractors/yadg.yml
+++ b/marda_registry/data/extractors/yadg.yml
@@ -60,6 +60,9 @@ installation:
     - method: pip
       packages:
         - yadg>=5.0a2
+    - method: pip
+      packages:
+        - git+https://github.com/dgbowl/yadg.git@5.0a2
 instructions: >-
     Install the package into a Python 3.9+ environment with
     `pip install yadg`. After activating the environment, the

--- a/marda_registry/data/extractors/yadg.yml
+++ b/marda_registry/data/extractors/yadg.yml
@@ -54,7 +54,7 @@ usage:
     - method: cli
       command: yadg extract {{ input_type }} {{ input_path }} {{ output_path }}
     - method: python
-      import: yadg
+      setup: yadg
       command: yadg.extractors.extract({{ input_path }}, {{ input_path }})
 installation:
     - method: pip

--- a/marda_registry/data/extractors/yadg.yml
+++ b/marda_registry/data/extractors/yadg.yml
@@ -17,8 +17,8 @@ supported_filetypes:
           Note: Only .ch files contained in the .dx archive are parsed.
     - id: phi-spe
     - id: panalytical-xrdml
-license: >-
-    GPL-3.0-only
+license:
+    spdx: GPL-3.0-only
 subject:
     - electrochemistry
     - voltammetry
@@ -52,10 +52,10 @@ source_repository: https://github.com/dgbowl/yadg
 documentation: https://dgbowl.github.io/yadg
 usage:
     - method: cli
-      command: yadg extract $input_filetype $input_file $output_file
+      command: yadg extract {{ input_type }} {{ input_path }} {{ output_path }}
     - method: python
       import: yadg
-      command: yadg.extractors.extract($input_filetype, $input_file)
+      command: yadg.extractors.extract({{ input_path }}, {{ input_path }})
 installation:
     - method: pip
       packages:

--- a/marda_registry/data/extractors/yadg.yml
+++ b/marda_registry/data/extractors/yadg.yml
@@ -59,10 +59,10 @@ usage:
 installation:
     - method: pip
       packages:
-        - yadg>=5.0a2
+          - yadg>=5.0a2
     - method: pip
       packages:
-        - git+https://github.com/dgbowl/yadg.git@5.0a2
+          - git+https://github.com/dgbowl/yadg.git@5.0a2
 instructions: >-
     Install the package into a Python 3.9+ environment with
     `pip install yadg`. After activating the environment, the

--- a/marda_registry/data/extractors/yadg.yml
+++ b/marda_registry/data/extractors/yadg.yml
@@ -51,7 +51,15 @@ citations:
 source_repository: https://github.com/dgbowl/yadg
 documentation: https://dgbowl.github.io/yadg
 usage:
-    - cli:yadg extract {{ file_type }} {{ file_path }}
+    - method: cli
+      command: yadg extract $input_filetype $input_file $output_file
+    - method: python
+      import: yadg
+      command: yadg.extractors.extract($input_filetype, $input_file)
+installation:
+    - method: pip
+      packages:
+        - yadg>=5.0a2
 instructions: >-
     Install the package into a Python 3.9+ environment with
     `pip install yadg`. After activating the environment, the


### PR DESCRIPTION
This PR depends on the following PR's to make sense:
- `usage` and `installation` schema: https://github.com/marda-alliance/metadata_extractors_schema/pull/22
- fix to the `extract` functionality of yadg: https://github.com/dgbowl/yadg/pull/110