### PR TITLE
`yadg` extractor more capabilities

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,6 @@
 *.mpr filter=lfs diff=lfs merge=lfs -text
 *.mpt filter=lfs diff=lfs merge=lfs -text
+*.ch filter=lfs diff=lfs merge=lfs -text
+*.dx filter=lfs diff=lfs merge=lfs -text
+*.spe filter=lfs diff=lfs merge=lfs -text
+*.xrdml filter=lfs diff=lfs merge=lfs -text

--- a/marda_registry/data/extractors/yadg.yml
+++ b/marda_registry/data/extractors/yadg.yml
@@ -11,6 +11,12 @@ supported_filetypes:
           Note: Several fields in file headers are not translated into meaningful
           parameters.
     - id: biologic-mpt
+    - id: agilent-ch
+    - id: agilent-dx
+      description: >-
+          Note: Only .ch files contained in the .dx archive are parsed.
+    - id: phi-spe
+    - id: panalytical-xrdml
 license: >-
     GPL-3.0-only
 subject:

--- a/marda_registry/data/filetypes/agilent-ch.yml
+++ b/marda_registry/data/filetypes/agilent-ch.yml
@@ -1,0 +1,19 @@
+---
+id: >-
+    agilent-ch
+name: >-
+    Agilent ChemStation export file
+description: >-
+    A binary data file created by Agilent ChemStation or OpenLab software, for liquid
+    chromatographs. The files contain the limits of the retention time axis as well as
+    the signal data.
+associated_vendors:
+    - Agilent
+    - HP
+subject:
+    - chromatography
+associated_instruments:
+    - Agilent 1260
+associated_software:
+    - Agilent ChemStation
+    - Agilent OpenLab

--- a/marda_registry/data/filetypes/agilent-ch.yml
+++ b/marda_registry/data/filetypes/agilent-ch.yml
@@ -5,7 +5,8 @@ name: >-
     Agilent ChemStation export file
 description: >-
     A binary data file created by Agilent ChemStation or OpenLab software, for liquid
-    chromatographs. The files contain the limits of the retention time axis as well as
+    chromatographs. The files contain the limits of the retention time axis as well
+    as
     the signal data.
 associated_vendors:
     - Agilent

--- a/marda_registry/data/filetypes/agilent-dx.yml
+++ b/marda_registry/data/filetypes/agilent-dx.yml
@@ -1,0 +1,17 @@
+---
+id: >-
+    agilent-dx
+name: >-
+    Agilent OpenLab data file
+description: >-
+    A raw data export file for Agilent OpenLab CDS. It is actually a zipped archive
+    containing other binary data file formats.
+associated_vendors:
+    - Agilent
+    - HP
+subject:
+    - chromatography
+associated_instruments:
+    - Agilent 1260
+associated_software:
+    - Agilent OpenLab

--- a/marda_registry/data/filetypes/panalytical-xrdml.yml
+++ b/marda_registry/data/filetypes/panalytical-xrdml.yml
@@ -4,7 +4,8 @@ id: >-
 name: >-
     PANalytical XRDML file
 description: >-
-    A structured XML file, containing data from diffraction experiments, developed by
+    A structured XML file, containing data from diffraction experiments, developed
+    by
     PANalytical.
 associated_vendors:
     - PANalytical

--- a/marda_registry/data/filetypes/panalytical-xrdml.yml
+++ b/marda_registry/data/filetypes/panalytical-xrdml.yml
@@ -1,0 +1,16 @@
+---
+id: >-
+    panalytical-xrdml
+name: >-
+    PANalytical XRDML file
+description: >-
+    A structured XML file, containing data from diffraction experiments, developed by
+    PANalytical.
+associated_vendors:
+    - PANalytical
+subject:
+    - x-ray diffraction
+associated_instruments:
+    - PANalytical X'Pert Powder
+associated_software:
+    - PANalytical HighScore

--- a/marda_registry/data/filetypes/phi-spe.yml
+++ b/marda_registry/data/filetypes/phi-spe.yml
@@ -4,7 +4,8 @@ id: >-
 name: >-
     PHI SPE Multipak file
 description: >-
-    A binary file containing the raw data from PHI spectrometers. The files contain an
+    A binary file containing the raw data from PHI spectrometers. The files contain
+    an
     ASCII header, followed by the data records in binary format.
 associated_vendors:
     - ULVAC-PHI

--- a/marda_registry/data/filetypes/phi-spe.yml
+++ b/marda_registry/data/filetypes/phi-spe.yml
@@ -1,0 +1,17 @@
+---
+id: >-
+    phi-spe
+name: >-
+    PHI SPE Multipak file
+description: >-
+    A binary file containing the raw data from PHI spectrometers. The files contain an
+    ASCII header, followed by the data records in binary format.
+associated_vendors:
+    - ULVAC-PHI
+subject:
+    - x-ray photoelectron spectroscopy
+    - Auger electron spectroscopy
+associated_instruments:
+    - PHI Quantum 2000
+associated_software:
+    - IGOR Pro

--- a/marda_registry/data/lfs/agilent-ch/hplc.CH
+++ b/marda_registry/data/lfs/agilent-ch/hplc.CH
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:43e8858e123321b0ac56317464fc601e9371be16015806b70693f766b62481a5
+size 86144

--- a/marda_registry/data/lfs/agilent-dx/hplc.dx
+++ b/marda_registry/data/lfs/agilent-dx/hplc.dx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c9ac55f91212697627b3f3ea3beebcc25874d8327953e198f4ad98cf3912abd
+size 6739148

--- a/marda_registry/data/lfs/panalytical-xrdml/xrd.xrdml
+++ b/marda_registry/data/lfs/panalytical-xrdml/xrd.xrdml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:59606024497a6dbb73207feb2e6beaad2e8d9a89321d8491b907f7137109c52c
+size 23173

--- a/marda_registry/data/lfs/phi-spe/xps.spe
+++ b/marda_registry/data/lfs/phi-spe/xps.spe
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5346857abe29f3f32a8741cc53697d78af6078d585961d0080ef1c904750a3e3
+size 29947


### PR DESCRIPTION
- adds `agilent-ch`, `agilent-dx`, `phi-spe`, and `panalytical-xrdml` filetypes
- adds example files into LFS
- adds above filetypes into `yadg`
- can be merged independently from #35.