### PR TITLE
Bump schemas to v0.2.0

### DIFF
--- a/marda_registry/app.py
+++ b/marda_registry/app.py
@@ -12,7 +12,7 @@ from fastapi import FastAPI, HTTPException
 from .models import Extractor, FileType
 from .utils import load_registry_collection
 
-__api_version__ = "0.1.0"
+__api_version__ = "0.2.0"
 
 
 app = FastAPI(
@@ -20,6 +20,8 @@ app = FastAPI(
     description=f"This server implements v{__api_version__} of the [MaRDA extractors WG](https://github.com/marda-alliance/metadata_extractors) registry API.",  # noqa: E501
     version=__api_version__,
 )
+
+api = FastAPI()
 
 db: pymongo.Database = pymongo.MongoClient().registry
 
@@ -89,5 +91,9 @@ async def load_data():
     _get_info()
 
 
+api.mount(f"/{__api_version__}", app)
+api.mount("/", app)
+
+
 if __name__ == "__main__":
-    uvicorn.run("__main__:app")
+    uvicorn.run("__main__:api")

--- a/marda_registry/data/extractors/rosettasciio.yaml
+++ b/marda_registry/data/extractors/rosettasciio.yaml
@@ -15,6 +15,8 @@ description: >-
     still particularly well represented.
 supported_filetypes:
     - id: renishaw-wdf
+      template:
+          input_type: renishaw
 license:
     spdx: GPL-3.0-only
 subject:
@@ -30,7 +32,7 @@ documentation: https://hyperspy.org/rosettasciio
 usage:
     - method: python
       setup: rsciio
-      command: rsciio.renishaw.file_reader({{ input_path }})
+      command: rsciio.{{ input_type }}.file_reader({{ input_path }})
       description: >-
           This usage instruction is specifically for the renishaw-wdf file type.
 installation:
@@ -40,7 +42,4 @@ installation:
     - method: pip
       packages:
           - git+https://github.com/hyperspy/rosettasciio
-instructions: >-
-    Install the package into a Python 3.9+ environment with
-    `pip install yadg`. After activating the environment, the
-    `extract` entrypoint will be available at the command-line.
+      requires_python: ~=3.6

--- a/marda_registry/data/extractors/yadg.yml
+++ b/marda_registry/data/extractors/yadg.yml
@@ -60,9 +60,11 @@ installation:
     - method: pip
       packages:
           - yadg>=5.0a2
+      requires_python: ~=3.9
     - method: pip
       packages:
           - git+https://github.com/dgbowl/yadg.git@5.0a5
+      requires_python: ~=3.9
 instructions: >-
     Install the package into a Python 3.9+ environment with
     `pip install yadg`. After activating the environment, the


### PR DESCRIPTION
This PR bumps the registry schemas to v0.2.0, which probably means we bump the registry version too, and update all the entries.

- [x] bump registry version
- [x] bump entries
- [x] deploy versioned URL (closes #5 for now)