### PR TITLE
Add a simple static web UI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,5 @@
 ---
+exclude: ^(marda_registry/data/|marda_registry/models/)
 repos:
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v4.5.0

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: uvicorn marda_registry.app:app --host 0.0.0.0 --port $PORT
+web: uvicorn marda_registry.api:api --host 0.0.0.0 --port $PORT

--- a/marda_registry/static/style.css
+++ b/marda_registry/static/style.css
@@ -1,0 +1,78 @@
+body {
+  background-color: #0B1B28;
+  color: #F8F8F8;
+  font-family: sans-serif;
+}
+
+.container {
+  max-width: 1000px;
+  margin: 0 auto;
+}
+
+.extractor {
+    border: 1px solid grey;
+    padding: 10px;
+}
+
+
+.filetype {
+    border: 1px solid grey;
+    padding: 10px;
+}
+
+.ft {
+  color: #EEFF41;
+}
+
+.ex {
+  color: #FFAB40;
+}
+
+.ft-id, .ft-id > a {
+  color: #EEFF41;
+  border-radius: 5px;
+  padding: 2px;
+  font-family: monospace;
+  font-weight: bold;
+}
+
+.ex-id, .ex-id > a {
+  color: #FFAB40;
+  border-radius: 5px;
+  padding: 2px;
+  font-family: monospace;
+  font-weight: bold;
+}
+
+a {
+    color: #58D0BB;
+}
+
+.navbar {
+  background-color: #0B1B28;
+  overflow: hidden;
+  font-size: 1.5em;
+  font-family: monospace;
+}
+
+.navbar ul {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
+.navbar li {
+  float: left;
+}
+
+.navbar a {
+  display: block;
+  color: #58D0BB;
+  text-align: center;
+  padding: 14px 16px;
+  text-decoration: none;
+}
+
+.navbar a:hover {
+  color: #F8F8F8;
+}

--- a/marda_registry/templates/base.html
+++ b/marda_registry/templates/base.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    {% block head %}
+    <meta charset="utf-8">
+    <link rel="shortcut icon" href="https://www.marda-alliance.org/wp-content/uploads/2023/04/cropped-favicon-32x32.png">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+    <link href="{{ url_for('static', path='/style.css') }}" rel="stylesheet">
+    <title>{% block title %}{% endblock %} - MaRDA Registry</title>
+    {% endblock %}
+</head>
+<body>
+    <div class="container">
+        <nav class="navbar">
+            <ul>
+                <li class="ex" ><a href="{{ url_for('get_extractors_html') }}">Extractors</a></li>
+                <li class="ft"><a href="{{ url_for('get_filetypes_html') }}">File types</a></li>
+                <li><a href="{{ url_for('get_info') }}">JSON API</a></li>
+                <li><a href="https://github.com/marda-alliance/metadata_extractors"><i class="fa fa-github"></i> GitHub</a></li>
+            </ul>
+        </nav>
+        {% block content %}
+        {% endblock %}
+    </div>
+</body>
+</html>

--- a/marda_registry/templates/extractor.html
+++ b/marda_registry/templates/extractor.html
@@ -1,0 +1,84 @@
+{% extends 'base.html' %}
+{% block title %}{{ ex['id'] | default('Not found') }}{% endblock %}
+{% block content %}
+{% if ex == None %}
+    <h1>Extractor not found</h1>
+    <p>Sorry, the extractor you requested was not found.</p>
+{% endif %}
+
+<h2><span class="ex-id">{{ ex['id'] }}</span> <span class="ex-name">({{ ex['name'] }})</span></h2>
+
+{% if ex['license'] %}
+<div clas="ex-license">
+    <i class="fa fa-balance-scale"></i>
+    {% if ex['license'].get('spdx') %}
+        <a href="https://spdx.org/licenses/{{ ex['license']['spdx'] }}" aria-label="SPDX License">{{ ex['license']['spdx'] }}</a>
+    {% else %}
+        <a href="{{ ex['license']['uri'] }}" aria-label="License">{{ ex['license']['uri'] }}</a>
+    {% endif %}
+</div>
+{% endif %}
+
+{% if ex['source_repository'] %}
+<div class="ex-repo">
+    <i class="fa fa-code-fork" aria-hidden="true"></i>
+    <a href="{{ ex['source_repository'] }}" aria-label="Source code repository">{{ ex['source_repository'] }}</a>
+</div>
+{% endif %}
+
+{% if ex['source_repository'] %}
+<div class="entry-docs">
+    <i class="fa fa-book" aria-hidden="true"></i>
+    <a href="{{ ex['documentation'] }}" aria-label="Documentation page">{{ ex['documentation'] }}</a>
+</div>
+{% endif %}
+
+{% if ex['description'] %}
+<div class="entry-description" aria-label="Description">
+    <p>{{ ex['description'] }}</p>
+</div>
+{% endif %}
+
+<h4>Instructions:</h4>
+<div class="ex-instructions">
+    {{ ex['instructions'] | default('None provided') }}
+</div>
+
+<h4>Supported file types:</h4>
+<ul>
+    {% for ft in ex['supported_filetypes'] %}
+        <li><span class="ft-id"><a href="../filetypes/{{ ft['id'] }}">{{ ft['id'] }}</a></span></li>
+        {% if ft['description'] %}
+            <ul>
+                <li class="ex-caveat-desc">{{ ft['description'] }}</li>
+            </ul>
+        {% endif %}
+    {% endfor %}
+</ul>
+
+<h4>References:</h4>
+<ul>
+    {% for ref in ex['citations'] %}
+        <li class="ex-citation">
+            <span class="ex-citation-type">{{ ref['type'] | title }}: </span>
+            <span class="ex-citation-creators">
+                {{ ', '.join(ref['creators']) }}
+            </span>
+            <span class="ex-citation-title">{{ ref['title'] }}</span>
+            <div class="ex-citation-uri">
+            {% if ref['uri'].startswith('doi:') %}
+                <span class="ex-citation-uri">
+                <a href="https://doi.org/{{ ref['uri'][4:] }}">{{ ref['uri'][4:] }}</a>
+                </span>
+            {% else %}
+                <span class="ex-citation-uri">
+                <a href="{{ ref['uri'] }}">{{ ref['uri'] }}</a>
+                </span>
+            {% endif %}
+            </div>
+        </li>
+    {% endfor %}
+</ul>
+
+<p><a href="../extractors">Return to the list of extractors</a></p>
+{% endblock %}

--- a/marda_registry/templates/extractors.html
+++ b/marda_registry/templates/extractors.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% block title %}Extractors{% endblock %}
+{% block content %}
+<h1>Extractors</h1>
+
+{% for ex in data %}
+    <div class="extractor">
+        <div class="entry-title">
+            <h2><span class="ex-id"><a href="./extractors/{{ ex['id'] }}">{{ ex['id'] }}</a></span> <span class="ex-name">({{ ex['name'] }})</span></h2>
+        </div>
+        <div class="entry-description">
+            <p>{{ ex['description'] }}</p>
+        </div>
+    </div>
+{% endfor %}
+{% endblock %}

--- a/marda_registry/templates/filetype.html
+++ b/marda_registry/templates/filetype.html
@@ -1,0 +1,23 @@
+{% extends 'base.html' %}
+{% block title %}{{ ft['id'] | default('Not found') }}{% endblock %}
+{% block content %}
+{% if ft == None %}
+    <h1>File Type not found</h1>
+    <p>Sorry, the file type you requested was not found.</p>
+{% endif %}
+
+<h2><span class="ft-id">{{ ft['id'] }}</span> <span class="ft-name">({{ ft['name'] }})</span></h2>
+
+<div class="entry-description">
+    <p>{{ ft['description'] }}</p>
+</div>
+
+Registered extractors:
+<ul>
+    {% for extractor in ft['registered_extractors'] %}
+        <li><span class="ex-id"><a href="../extractors/{{ extractor }}">{{ extractor }}</a></span></li>
+    {% endfor %}
+</ul>
+
+<p><a href="../filetypes">Return to the list of file types</a></p>
+{% endblock %}

--- a/marda_registry/templates/filetypes.html
+++ b/marda_registry/templates/filetypes.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% block title %}File Types{% endblock %}
+{% block content %}
+<h1>File Types</h1>
+
+{% for ft in data %}
+    <div class="filetype">
+        <div class="entry-title">
+            <h2><span class="ft-id"><a href="./filetypes/{{ ft['id'] }}">{{ ft['id'] }}</a></span> <span class="ft-name">({{ ft['name'] }})</span></h2>
+        </div>
+        <div class="entry-description">
+            <p>{{ ft['description'] }}</p>
+        </div>
+    </div>
+{% endfor %}
+{% endblock %}


### PR DESCRIPTION
This PR adds some simple Jinja templates for the registry to add a simple static web UI.

It also moves the location that the real API is hosted at (now under `/api` and `/api/<version>`) and better nests some of the API responses. This should constitute an API version bump (which will need the corresponding change at the API repo). In future we could consider maintaining both versions from the same app but that doesn't seem worth it here.