### PR TITLE
Add `qe-tools` to registry with support for QE PW and QE CP input files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,4 @@
 *.dx filter=lfs diff=lfs merge=lfs -text
 *.spe filter=lfs diff=lfs merge=lfs -text
 *.xrdml filter=lfs diff=lfs merge=lfs -text
+*.in filter=lfs diff=lfs merge=lfs -text

--- a/marda_registry/data/extractors/quantumespresso.yml
+++ b/marda_registry/data/extractors/quantumespresso.yml
@@ -1,0 +1,40 @@
+---
+id: qe-tools
+name: Tools for Quantum ESPRESSO
+description: A set of tools for the Quantum ESPRESSO suite of electronic-structure simulation codes.
+subject:
+    - atomistic simulation
+    - electronic structure calculations
+    - materials modeling
+source_repository: https://github.com/aiidateam/qe-tools
+usage:
+    - method: python
+      setup: qe_tools
+      command: qe_tools.extractors.extract({{ input_path }}, {{ input_type }})
+installation:
+    - method: pip
+      packages:
+          - git+https://github.com/edan-bainglass/qe-tools.git@marda-extractors-support
+      requires_python: ">=3.8"
+citations:
+    - uri: doi:10.1088/0953-8984/21/39/395502
+      creators:
+          - P. Giannozzi
+      title: "QUANTUM ESPRESSO: a modular and open-source software project for quantum simulations of materials"
+      type: article
+    - uri: https://github.com/aiidateam/qe-tools
+      creators:
+          - G. Pizzi
+      title: Repository of Quantum ESPRESSO tools
+      type: software
+supported_filetypes:
+    - id: qe-pw-in
+      description: An input file for the Quantum ESPRESSO PW package
+      template:
+        input_type: PW
+    - id: qe-cp-in
+      description: An input file for the Quantum ESPRESSO CP package
+      template:
+        input_type: CP
+license:
+    spdx: GPL2

--- a/marda_registry/data/filetypes/qe-cp-in.yml
+++ b/marda_registry/data/filetypes/qe-cp-in.yml
@@ -1,0 +1,10 @@
+---
+id: qe-cp-in
+name: QE CP input file
+description: An input file for Quantum ESPRESSO's Car-Parrinello (CP) ab-initio molecular dynamics package.
+subject:
+    - physics
+    - chemistry
+    - materials science
+associated_software:
+    - Quantum ESPRESSO

--- a/marda_registry/data/filetypes/qe-pw-in.yml
+++ b/marda_registry/data/filetypes/qe-pw-in.yml
@@ -1,0 +1,13 @@
+---
+id: >-
+    qe-pw-in
+name: >-
+    QE PW input file
+description: >-
+    An input file for Quantum ESPRESSO's planewave (PW) package.
+subject:
+    - physics
+    - chemistry
+    - materials science
+associated_software:
+    - Quantum ESPRESSO

--- a/marda_registry/data/lfs/qe-cp-in/cp.in
+++ b/marda_registry/data/lfs/qe-cp-in/cp.in
@@ -1,0 +1,49 @@
+ &control
+    title = ' Water Molecule ',
+    calculation = 'cp',
+    restart_mode = 'from_scratch',
+    ndr = 51,
+    ndw = 51,
+    nstep  = 100,
+    iprint = 100,
+    isave  = 100,
+    tstress = .TRUE.,
+    tprnfor = .TRUE.,
+    dt    = 5.0d0,
+    etot_conv_thr = 1.d-9,
+    ekin_conv_thr = 1.d-4,
+    prefix = 'h2o'
+    verbosity = 'medium'
+ /
+ &system
+    ibrav = 14,
+    celldm(1) = 12.0,
+    celldm(2) = 1.0,
+    celldm(3) = 1.0,
+    celldm(4) = 0.0,
+    celldm(5) = 0.0,
+    celldm(6) = 0.0,
+    nat  = 3,
+    ntyp = 2,
+    nbnd = 4,
+    ecutwfc = 80.0,
+ /
+ &electrons
+    emass = 400.d0,
+    emass_cutoff = 2.5d0,
+    orthogonalization = 'ortho',
+    electron_dynamics = 'damp',
+    electron_damping = 0.2
+ /
+ &ions
+    ion_dynamics = 'none',
+    ion_radius(1) = 0.8d0,
+    ion_radius(2) = 0.8d0,
+ /
+ATOMIC_SPECIES
+ O 16.0d0 O.blyp-mt.UPF
+ H 1.00d0 H.blyp-vbc.UPF
+ATOMIC_POSITIONS (bohr)
+   O     0.0099    0.0099    0.0000  0 0 0
+   H     1.8325   -0.2243   -0.0001  1 1 1
+   H    -0.2243    1.8325    0.0002  1 1 1

--- a/marda_registry/data/lfs/qe-pw-in/pw.in
+++ b/marda_registry/data/lfs/qe-pw-in/pw.in
@@ -1,0 +1,27 @@
+ &control
+    calculation = 'relax',
+ /
+ &system
+    ibrav = 1,
+    celldm(1) = 12.0,
+    nat  = 3,
+    ntyp = 2,
+    nbnd = 4,
+    ecutwfc = 80,
+    ecutfock=160,
+    input_dft = 'X3LYP'
+    exxdiv_treatment = 'gygi-baldereschi'
+    x_gamma_extrapolation = .TRUE.
+ /
+ &electrons
+ /
+ &ions
+ /
+ATOMIC_SPECIES
+ O 16.0d0 O.blyp-mt.UPF
+ H 1.00d0 H.blyp-vbc.UPF
+ATOMIC_POSITIONS (bohr)
+   O     0.0099    0.0099    0.0000
+   H     1.8325   -0.2243   -0.0001
+   H    -0.2243    1.8325    0.0002
+K_POINTS gamma


### PR DESCRIPTION
Adding `qe-tools` to the registry. For now, it will support QE's PW and CP input files. Others may follow depending on how this goes.

A few notes:

1. Had to add an `extract` function as a middle layer between MaRDA and `qe-tools` classes. Open PR pending review. For now, the extractor schema added to the registry points to my `qe-tools` fork. Let's see how that goes.

2. The `command` for my extractor is `qe_tools.extractors.extract({{ input_path }}, {{ input_type }})`, where `input_path` is expected to be the path to the file, and `input_type` is `PW` or `CP`. I defined `input_type` under each `supported_filetypes` entry in the schema. Not sure if this is the way.