### PR TITLE
Add example Raman file and update LFS config

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,1 @@
-*.mpr filter=lfs diff=lfs merge=lfs -text
-*.mpt filter=lfs diff=lfs merge=lfs -text
-*.ch filter=lfs diff=lfs merge=lfs -text
-*.dx filter=lfs diff=lfs merge=lfs -text
-*.spe filter=lfs diff=lfs merge=lfs -text
-*.xrdml filter=lfs diff=lfs merge=lfs -text
-*.in filter=lfs diff=lfs merge=lfs -text
+marda_registry/data/lfs/*/*.* filter=lfs diff=lfs merge=lfs -text

--- a/marda_registry/data/lfs/renishaw-wdf/raman_example.wdf
+++ b/marda_registry/data/lfs/renishaw-wdf/raman_example.wdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68e7ae743237539b200c69336e7a1ba1ebe06cb8d0777b3196228394e62661d8
+size 77818


### PR DESCRIPTION
We should probably just track all files in the `./lfs` directory as LFS files (with exclusions done on a case-by-case basis). This PR does that and also adds an example Raman file from Renishaw.