### PR TITLE
Add `zeiss-tiff` and `zeiss-tiff-meta` filetypes and extractor

### DIFF
--- a/marda_registry/data/extractors/zeiss-tiff-meta.yml
+++ b/marda_registry/data/extractors/zeiss-tiff-meta.yml
@@ -1,0 +1,31 @@
+---
+id: >-
+    zeiss-tiff-meta
+name: >-
+    Zeiss TIFF Metadata Extractor
+description: >-
+    For reading metadata from Zeiss SEM tiff files and extracting the physical scale.
+supported_filetypes:
+    - id: zeiss-tiff
+license:
+    spdx: MIT
+subject:
+    - electron-microscopy
+    - imaging
+source_repository: https://github.com/ks00x/zeiss_tiff_meta
+documentation: https://github.com/ks00x/zeiss_tiff_meta
+citations:
+    - uri: https://github.com/ks00x/zeiss_tiff_meta
+      creators:
+          - K. Schwarzburg
+      title: 'zeiss_tiff_meta github repository'
+      type: software
+usage:
+    - method: python
+      setup: zeisstiffmeta
+      command: meta_to_dict(zeiss_meta({{ input_path }}))
+installation:
+    - method: pip
+      packages:
+          - git+https://github.com/ks00x/zeiss_tiff_meta
+      requires_python: ~=3.4

--- a/marda_registry/data/filetypes/zeiss-tiff.yml
+++ b/marda_registry/data/filetypes/zeiss-tiff.yml
@@ -1,0 +1,19 @@
+---
+id: >-
+    zeiss-tiff
+name: >-
+    Zeiss TIFF
+description: >-
+    A specialisation of the Tag Image File Format (TIFF) that includes metadata
+    annotations from Zeiss microscopes.
+associated_vendors:
+    - Zeiss
+subject:
+    - microscopy
+associated_instruments:
+    - ZEISS GeminiSEM
+    - ZEISS Sigma
+    - ZEISS MultiSEM
+    - ZEISS EVO
+associated_software:
+    - ZEISS SmartSEM

--- a/marda_registry/data/lfs/zeiss-tiff/example.tif
+++ b/marda_registry/data/lfs/zeiss-tiff/example.tif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:809fbc772c631f36978cf96a6a8c65979693d59c36f7e3f75f7c42f2f7b7e397
+size 892678


### PR DESCRIPTION
This PR adds ZEISS TIFF and an associated extractor to the registry. We should find another manufacturer with similar metadata to test out how these things could interact in the future.

Thanks to @ks00x, the author of this code!