### PR TITLE
Fix `zeiss-tiff-meta` usage instructions

### DIFF
--- a/marda_registry/data/extractors/zeiss-tiff-meta.yml
+++ b/marda_registry/data/extractors/zeiss-tiff-meta.yml
@@ -23,7 +23,7 @@ citations:
 usage:
     - method: python
       setup: zeisstiffmeta
-      command: meta_to_dict(zeiss_meta({{ input_path }}))
+      command: zeisstiffmeta.meta_to_dict(zeisstiffmeta.zeiss_meta({{ input_path }}))
 installation:
     - method: pip
       packages:


### PR DESCRIPTION
Need to use the full path after the import.