### PR TITLE
Add Galvani entry

### DIFF
--- a/marda_registry/data/extractors/galvani.yml
+++ b/marda_registry/data/extractors/galvani.yml
@@ -32,12 +32,12 @@ usage:
     - method: python
       setup: galvani
       command: galvani.BioLogic.MPRFile({{ input_path }})
-      supported_filetypes: 
+      supported_filetypes:
         - biologic-mpr
     - method: python
       setup: galvani
       command: galvani.BioLogic.MPTfile({{ input_path }})
-      supported_filetypes: 
+      supported_filetypes:
         - biologic-mpt
 installation:
     - method: pip

--- a/marda_registry/data/extractors/galvani.yml
+++ b/marda_registry/data/extractors/galvani.yml
@@ -5,12 +5,16 @@ name: >-
     Galvani
 description: >-
     Read proprietary file formats from electrochemical test stations, including
-    BioLogic MPR and MPT files, and the res format from Arbin.
+    BioLogic MPR and MPT files, and the res format from Arbin. 
+
+    NB: The Arbin res format is not directly supported via datatractor as the data
+    returned in this case is a view into a sqlite database.
 supported_filetypes:
     - id: biologic-mpr
       description: >-
           Note: support for MPR files created by ECLab >= 11.50 requires 
           `galvani>=0.4`.
+    - id: biologic-mpt
 license:
     spdx: GPL-3.0-only
 subject:
@@ -28,6 +32,13 @@ usage:
     - method: python
       setup: galvani
       command: galvani.BioLogic.MPRFile({{ input_path }})
+      supported_filetypes: 
+        - biologic-mpr
+    - method: python
+      setup: galvani
+      command: galvani.BioLogic.MPTfile({{ input_path }})
+      supported_filetypes: 
+        - biologic-mpt
 installation:
     - method: pip
       packages:

--- a/marda_registry/data/extractors/galvani.yml
+++ b/marda_registry/data/extractors/galvani.yml
@@ -1,0 +1,34 @@
+---
+id: >-
+    galvani
+name: >-
+    Galvani
+description: >-
+    Read proprietary file formats from electrochemical test stations
+supported_filetypes:
+    - id: biologic-mpr
+      description: >-
+          Note: support for MPR files created by ECLab >= 11.50 requires 
+          `galvani>0.3`.
+license:
+    spdx: GPL-3.0-only
+subject:
+    - electrochemistry
+    - voltammetry
+    - impedance spectropscopy
+citations:
+    - uri: https://github.com/echemdata/galvani
+      creators:
+          - C. Kerr
+      title: galvani github repository
+      type: software
+source_repository: https://github.com/echemdata/galvani
+usage:
+    - method: python
+      setup: galvani
+      command: galvani.BioLogic.MPRFile({{ input_path }})
+installation:
+    - method: pip
+      packages:
+          - galvani~=0.3.0
+      requires_python: '>=3.6'

--- a/marda_registry/data/extractors/galvani.yml
+++ b/marda_registry/data/extractors/galvani.yml
@@ -4,12 +4,13 @@ id: >-
 name: >-
     Galvani
 description: >-
-    Read proprietary file formats from electrochemical test stations
+    Read proprietary file formats from electrochemical test stations, including
+    BioLogic MPR and MPT files, and the res format from Arbin.
 supported_filetypes:
     - id: biologic-mpr
       description: >-
           Note: support for MPR files created by ECLab >= 11.50 requires 
-          `galvani>0.3`.
+          `galvani>=0.4`.
 license:
     spdx: GPL-3.0-only
 subject:
@@ -30,5 +31,5 @@ usage:
 installation:
     - method: pip
       packages:
-          - galvani~=0.3.0
+          - galvani ~= 0.4
       requires_python: '>=3.6'


### PR DESCRIPTION
Could also add `arbin-res` support via `galvani` but this file has much more awkward dependencies (maybe this is a good test for us). For now we cannot easily use it.