### PR TITLE
Add NewareNDA extractor entry

### DIFF
--- a/marda_registry/data/extractors/neware-nda-reader.yaml
+++ b/marda_registry/data/extractors/neware-nda-reader.yaml
@@ -9,6 +9,7 @@ supported_filetypes:
     - id: neware-nda
 license:
     spdx: BSD-3-Clause
+    uri: https://github.com/Solid-Energy-Systems/NewareNDA/blob/master/LICENSE
 subject:
     - electrochemistry
 citations:

--- a/marda_registry/data/extractors/neware-nda-reader.yaml
+++ b/marda_registry/data/extractors/neware-nda-reader.yaml
@@ -1,0 +1,49 @@
+---
+id: >-
+    NewareNDA 
+name: >-
+    NewareNDA
+description: >-
+    Python module and command line tool for reading and converting Neware nda and ndax battery cycling data files. 
+supported_filetypes:
+    - id: neware-nda
+license:
+    spdx: BSD-3-Clause
+subject:
+    - electrochemistry
+citations:
+    - uri: https://github.com/Solid-Energy-Systems/NewareNDA
+      creators:
+          - D. Cogswell
+      title: NewareNDA github repository
+      type: software
+source_repository: https://github.com/Solid-Energy-Systems/NewareNDA
+usage:
+    - method: cli
+      command: NewareNDA-cli.py {{ input_path }} --format csv {{ output_path }}
+    - method: cli
+      command: NewareNDA-cli.py {{ input_path }} --format excel {{ output_path }}
+    - method: cli
+      command: NewareNDA-cli.py {{ input_path }} --format feather {{ output_path }}
+    - method: cli
+      command: NewareNDA-cli.py {{ input_path }} --format hdf {{ output_path }}
+    - method: cli
+      command: NewareNDA-cli.py {{ input_path }} --format json {{ output_path }}
+    - method: cli
+      command: NewareNDA-cli.py {{ input_path }} --format parquet {{ output_path }}
+    - method: cli
+      command: NewareNDA-cli.py {{ input_path }} --format pickle {{ output_path }}
+    - method: cli
+      command: NewareNDA-cli.py {{ input_path }} --format stata {{ output_path }}
+    - method: python
+      setup: NewareNDA 
+      command: NewareNDA.read({{ input_path }})
+installation:
+    - method: pip
+      packages:
+          - NewareNDA >= 2024
+      requires_python: '>=3.6'
+instructions: >-
+    Install the package into a Python 3.6+ environment with
+    `pip install NewareNDA`. The results will be returned as
+    a pandas dataframe.


### PR DESCRIPTION
This PR adds the NewareNDA Python package as an extractor of our `neware-nda` file type.

Perhaps of interest to @d-cogswell, the author of the package (feel free to suggest any changes).

In terms of implementation, I have added several very similar CLI invocations for each of the support output file formats, which could maybe be merged/templated after a future schema update.

We're also missing example files for the `neware-nda` file type (which is in fact two types, `.nda` and `.ndax` -- could also be separated...). There's an open PR and issue about adding test data at https://github.com/Solid-Energy-Systems/NewareNDA/issues/48 that we could poach from to set up our own validation pipelines here.
