### PR TITLE
Update QE extractor installation path to pypi

### DIFF
--- a/marda_registry/data/extractors/quantumespresso.yml
+++ b/marda_registry/data/extractors/quantumespresso.yml
@@ -14,7 +14,7 @@ usage:
 installation:
     - method: pip
       packages:
-          - git+https://github.com/edan-bainglass/qe-tools.git@marda-extractors-support
+          - qe-tools>=2.2
       requires_python: ">=3.8"
 citations:
     - uri: doi:10.1088/0953-8984/21/39/395502


### PR DESCRIPTION
`qe-tools v2.2.0` is officially released with support for this extractor.